### PR TITLE
Fix for nginx and paths containing "/Modules"

### DIFF
--- a/emoncms.conf
+++ b/emoncms.conf
@@ -8,19 +8,24 @@ server {
     # Make site accessible from http://localhost/
     server_name localhost;
 
+    # Make sure requests to URLs with /Modules do not
+    # get rewritten to /index.php?q=
+    # This allows plugins like "app" to work.
+    location /Modules { }
+
     location / {
         # First attempt to serve request as file, then
         # as directory, then fall back to displaying a 404.
         try_files $uri $uri/ =404;
         # Uncomment to enable naxsi on this location
         # include /etc/nginx/naxsi.rules
-                rewrite ^/(.*)$ /index.php?q=$1 last;
+        rewrite ^/(.*)$ /index.php?q=$1 last;
     }
 
-        location ~* ^.+.(jpg|jpeg|gif|css|png|js|ico|xml)$ {
-            expires 30d;
-            root /var/www/emoncms;
-        }
+    location ~* ^.+.(jpg|jpeg|gif|css|png|js|ico|xml)$ {
+        expires 30d;
+        root /var/www/emoncms;
+    }
 
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     location ~ \.php$ {
@@ -33,6 +38,5 @@ server {
         fastcgi_pass unix:/var/run/php5-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;
-        }
+    }
 }
-


### PR DESCRIPTION
I couldn't get the "app" plugins to work because the URLs were incorrectly getting rewritten to `index.php?q=` format. This fixes it so the URLs get passed through.
